### PR TITLE
Add support for raw bytes, UUID and int128 forms

### DIFF
--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -56,6 +56,16 @@ module ULID
       output
     end
 
+    # returns the binary uint128 in base16 UUID format
+    def encode16
+      self.bytes.unpack("H8H4H4H4H*").join("-")
+    end
+
+    def encode10
+      (hi, lo) = self.bytes.unpack('Q>Q>')
+      (hi << 64) | lo
+    end
+
     def random_bytes
       SecureRandom.random_bytes(10)
     end

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -8,7 +8,7 @@ module ULID
     include Generate
     include Compare
 
-    attr_reader :seed, :bytes, :time, :ulid
+    attr_reader :seed, :bytes, :time
 
     # Create a new instance of a ULID::Identifier.
     #
@@ -35,13 +35,36 @@ module ULID
           @seed = seed
         end
       when String
-        if start.size != 26
-          raise ArgumentError.new("invalid ULID string, must be 26 characters")
+        case start.size
+        when 16
+          # assume byte form of ULID (Should be Encoding::ASCII_8BIT)
+          @bytes = start.b
+        when 26
+          # parse ULID string into bytes
+          @ulid = start.upcase
+          @bytes = decode(@ulid)
+        when 36
+          # parse UUID string into bytes
+          @bytes = decode16(start)
+        else
+          raise ArgumentError.new("invalid ULID or UUID string - must be 16, 26, or 36 characters")
         end
 
-        # parse string into bytes
-        @ulid = start.upcase
-        @bytes = decode(@ulid)
+        raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
+
+        @time, @seed = unpack_decoded_bytes(@bytes)
+      when Integer
+        # parse integer (BigNum) into bytes
+        @bytes = decode10(start)
+
+        raise ArgumentError.new("invalid ULID or UUID") if @bytes.size != 16
+
+        @time, @seed = unpack_decoded_bytes(@bytes)
+      when Array
+        # parse Array(16) into bytes
+        @bytes = start.pack("C*")
+
+        raise ArgumentError.new("invalid Byte Array") if @bytes.size != 16
 
         @time, @seed = unpack_decoded_bytes(@bytes)
       else
@@ -54,11 +77,20 @@ module ULID
         # an ASCII_8BIT encoded string, should be 16 bytes
         @bytes = time_bytes + @seed
       end
-
-      if @ulid.nil?
-        # the lexically sortable Base32 string we actually care about
-        @ulid = encode32
-      end
     end
+
+    def ulid
+        # the lexically sortable Base32 string we actually care about
+      @ulid ||= encode32
+    end
+
+    def uuid
+      @uuid ||= encode16
+    end
+
+    def int128
+      @int128 ||= encode10
+    end
+
   end
 end

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -38,6 +38,14 @@ module ULID
       out
     end
 
+    def decode16(input)
+      [input.delete("-")].pack("H*")
+    end
+
+    def decode10(input)
+      [input >> 64, input & 0xFFFFFFFFFFFFFFFF].pack("Q>Q>")
+    end
+
     def unpack_decoded_bytes(packed_bytes)
       time_bytes = packed_bytes[0..5].bytes.map(&:to_i)
       seed = packed_bytes[6..-1]

--- a/spec/ulid_spec.rb
+++ b/spec/ulid_spec.rb
@@ -4,8 +4,11 @@ require "spec_helper"
 #               --------------------------
 #               0DHWZ1DT60
 #                         60ZVCSJFXBTG0J2N
-KNOWN_STRING = '01ARYZ6RR0T8CNRGXPSBZSA1PY'
-KNOWN_TIME = Time.parse('2016-07-30 22:36:16 UTC')
+KNOWN_STRING = "01ARYZ6RR0T8CNRGXPSBZSA1PY"
+KNOWN_TIME = Time.parse("2016-07-30 22:36:16 UTC")
+KNOWN_UUID = "01563df3-6300-d219-5c43-b6caff9506de"
+KNOWN_BYTES = "\x01V=\xF3c\x00\xD2\x19\\C\xB6\xCA\xFF\x95\x06\xDE".b
+KNOWN_UINT128 = 1777022035688232904178850488005232350
 
 describe ULID do
   it "has a version number" do
@@ -76,6 +79,21 @@ describe ULID do
     end
   end
 
+  describe '.uuid' do
+    it 'generates a valid UUID' do
+      ulid = ULID.new KNOWN_STRING
+      expect(ulid.uuid).to eq(KNOWN_UUID)
+    end
+  end
+
+  describe '.bytes' do
+    it 'from a valid UUID' do
+      ulid = ULID.new KNOWN_UUID
+      expect(ulid.bytes).to eq(KNOWN_BYTES)
+    end
+  end
+
+
   describe ULID::Identifier do
     context 'with no initialization value' do
       it 'generates a random value for the current time' do
@@ -127,6 +145,78 @@ describe ULID do
       it 'generates with lowercase alphabet' do
         first = ULID.new KNOWN_STRING
         other = ULID.new KNOWN_STRING.downcase
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'raises an error for invalid ULID string' do
+        expect { ULID.new("not a valid ULID!") }.to raise_error(ArgumentError)
+        expect { ULID.new("") }.to raise_error(ArgumentError)
+        expect { ULID.new(KNOWN_STRING + KNOWN_STRING) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with Bytes string arg' do
+      it 'supports byteform' do
+        first = ULID.new
+        other = ULID.new first.bytes
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+    end
+
+    context 'with UUID string arg' do
+      it 'supports UUID' do
+        first = ULID.new KNOWN_UUID
+        other = ULID.new KNOWN_STRING
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'supports UUID case insensitive' do
+        first = ULID.new KNOWN_UUID.downcase
+        other = ULID.new KNOWN_UUID.upcase
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to eq(first.time)
+      end
+
+      it 'supports UUID self generated' do
+        first = ULID.new
+        other = ULID.new first.uuid
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+    end
+
+    context 'with uInt128 arg' do
+      it 'supports BigNum' do
+        first = ULID.new
+        other = ULID.new first.int128
+
+        expect(other.ulid).to eq(first.ulid)
+        expect(other.seed).to eq(first.seed)
+        expect(other.bytes).to eq(first.bytes)
+        expect(other.time).to be_within(0.001).of(first.time)
+      end
+
+      it 'supports BigNum self generated' do
+        first = ULID.new KNOWN_UINT128
+        other = ULID.new KNOWN_STRING
 
         expect(other.ulid).to eq(first.ulid)
         expect(other.seed).to eq(first.seed)


### PR DESCRIPTION
A ULID is nothing more than an uInt128 with encoding convenience. This PR enables the conversion to / from UUID forms to a ULID. Likewise enables support of the BigNum (int128) decimal form.

The following are all the same:
```
ULID.new(1777022035688232904178850488005232350)
ULID.new("\x01V=\xF3c\x00\xD2\x19\\C\xB6\xCA\xFF\x95\x06\xDE")
ULID.new("01563df3-6300-d219-5c43-b6caff9506de")
ULID.new("01ARYZ6RR0T8CNRGXPSBZSA1PY")
```

Likewise:
```
token = ULID.new("01ARYZ6RR0T8CNRGXPSBZSA1PY")
token.ulid    # "01ARYZ6RR0T8CNRGXPSBZSA1PY"
token.uuid    # "01563df3-6300-d219-5c43-b6caff9506de"
token.int128  # 1777022035688232904178850488005232350
token.bytes   # "\x01V=\xF3c\x00\xD2\x19\\C\xB6\xCA\xFF\x95\x06\xDE"

# 01ARYZ6RR0T8CNRGXPSBZSA1PY
```