### PR TITLE
Hotfix and cleanup ULID optimizations

### DIFF
--- a/lib/ulid/constants.rb
+++ b/lib/ulid/constants.rb
@@ -24,7 +24,7 @@ module ULID
     # B32_CROCKFORD_CHARS = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
     # B32_RCF4648_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
 
-    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ".upcase.freeze
-    B32_RCF4648_FRAGMENT = "IJKLMNOPQRSTUV".downcase.freeze # forcing downcase becase .to_s(32) is always lowercase
+    B32_CROCKFORD_FRAGMENT = "JKMNPQRSTVWXYZ"
+    B32_RCF4648_FRAGMENT = "ijklmnopqrstuv" # downcase because .to_s(32) is always lowercase
   end
 end

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -9,8 +9,9 @@ module ULID
 
     # returns the binary ULID as Base32 encoded string.
     def encode32
-      (hi, lo) = bytes.unpack("Q>Q>")
-      value = (hi << 64) | lo
+      high = bytes.unpack1("Q>")
+      low = bytes.unpack1("@8Q>")
+      value = (high << 64) | low
 
       # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
       # assumes that the value is a 128-bit integer
@@ -19,7 +20,7 @@ module ULID
       b32.tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT)
       b32.upcase!
 
-      return "0" + b32 if b32.length == 25
+      return "0#{b32}" if b32.length == 25
 
       b32
     end

--- a/lib/ulid/generate.rb
+++ b/lib/ulid/generate.rb
@@ -15,7 +15,9 @@ module ULID
       # use the RFC4648 Base32 encoding and convert to Crockford's Base32 with a simple translate
       # assumes that the value is a 128-bit integer
       # also assumes that .to_s(32) is lowercase
-      b32 = value.to_s(32).tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT).upcase!
+      b32 = value.to_s(32)
+      b32.tr!(B32_RCF4648_FRAGMENT, B32_CROCKFORD_FRAGMENT)
+      b32.upcase!
 
       return "0" + b32 if b32.length == 25
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -69,7 +69,7 @@ module ULID
         @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now.utc
+        @time = Time.now
         @seed = random_bytes
       end
 

--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -69,7 +69,7 @@ module ULID
         @time, @seed = unpack_ulid_bytes(@bytes)
       else
         # unrecognized initial values type given, just generate fresh ULID
-        @time = Time.now
+        @time = Time.now.utc
         @seed = random_bytes
       end
 

--- a/lib/ulid/parse.rb
+++ b/lib/ulid/parse.rb
@@ -22,7 +22,7 @@ module ULID
     end
 
     def unpack_ulid_bytes(packed_bytes)
-      time_int, _ = ("\x00\x00" + packed_bytes).unpack("Q>")
+      time_int = ("\x00\x00#{packed_bytes}").unpack1("Q>")
       seed = packed_bytes[6..-1]
 
       [Time.at(time_int.to_f / 1000.0), seed]

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,4 +1,3 @@
 module ULID
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end
-


### PR DESCRIPTION
The main change in this PR is the fix in https://github.com/Shopify/ulid-ruby/pull/8/commits/3ba0841933cc737d5bd65bfc9f5398376e9e080f to prevent `b32` from being `nil` in the absence of changes when modified by `tr!` and `upcase!`. This will fix [intermittent failures](https://buildkite.com/shopify/shopify-test-onboarding/builds/1018578#018fffff-6e95-4972-a08b-ca7d90c4121f) which we sometimes encounter in integrating the forked gem to caller code. 

While I was at it, I happened to notice that there was also some unresolved PR feedback on https://github.com/abachman/ulid-ruby/pull/10 so I figured I may as well solve those also - per https://github.com/Shopify/ulid-ruby/pull/8/commits/7d82497d4103fb01ae35e63040220d684255c5be .