### PR TITLE
Fix buggy method delegation

### DIFF
--- a/lib/ulid/identifier.rb
+++ b/lib/ulid/identifier.rb
@@ -92,11 +92,14 @@ module ULID
       @int128 ||= encode10
     end
 
+    def to_a
+      bytes.bytes
+    end
+
     alias_method :to_s, :ulid
     alias_method :to_str, :ulid
     alias_method :b, :bytes
     alias_method :to_int, :to_i
-    alias_method :to_a, :bytes.bytes
 
   end
 end

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,3 +1,3 @@
 module ULID
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end


### PR DESCRIPTION
I believe this snippet was just meant to alias `.to_a` to the raw bytes array, but was previously dereferencing a symbol - which did not fail statically but would fail at runtime or in generating new `.rbi` files for the gem when integrating to caller code:

<img width="1496" alt="image" src="https://github.com/Shopify/ulid-ruby/assets/9891776/921b1da5-3cea-4f60-b354-f1b9d36ace0f">